### PR TITLE
Add support for Date object in monthly methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,6 +129,10 @@ dist
 .yarn/install-state.gz
 .pnp.*
 
+# lockfiles
+package-lock.json
+yarn.lock
+
 # Custom
 /lib
 index.js

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "hive-bedrock-api",
-    "version": "0.1.0-beta.2",
+    "version": "0.1.0-beta.3",
     "description": "An API wrapper for the Hive Minecraft Bedrock Edition server.",
     "main": "lib/index.js",
     "types": "lib/index.d.ts",

--- a/src/methods/getMonthlyLeaderboard.ts
+++ b/src/methods/getMonthlyLeaderboard.ts
@@ -13,6 +13,7 @@ export default async function getMonthlyLeaderboard<G extends GAME>(
     options: {
         year?: number;
         month?: number;
+        date?: Date;
         skip?: number;
         amount?: number;
     }
@@ -23,6 +24,7 @@ export default async function getMonthlyLeaderboard<G extends GAME>(
     options?: {
         year?: number;
         month?: number;
+        date?: Date;
         skip?: number;
         amount?: number;
     }
@@ -48,6 +50,11 @@ export default async function getMonthlyLeaderboard<G extends GAME>(
         let month = options.month ?? new Date().getMonth() + 1;
         let amount = options.amount ?? 100;
         let skip = options.skip ?? 0;
+
+        if (options.date) {
+            year = options.date.getFullYear();
+            month = options.date.getMonth() + 1;
+        }
 
         try {
             let { data, error } = await fetchData(

--- a/src/methods/getMonthlyStats.ts
+++ b/src/methods/getMonthlyStats.ts
@@ -25,6 +25,7 @@ export default async function getMonthlyStats<G extends GAME>(
     options: {
         year?: number;
         month?: number;
+        date?: Date;
     }
 ): Promise<MethodResponse<GAME_STATS<BASE_GAME_MONTHLY>[G]>>;
 
@@ -39,6 +40,7 @@ export default async function getMonthlyStats<G extends GAME>(
     options?: {
         year?: number;
         month?: number;
+        date?: Date;
         skip?: number;
         amount?: number;
     }
@@ -80,6 +82,11 @@ export default async function getMonthlyStats<G extends GAME>(
     if (options && typeof game === "string") {
         let year = options.year ?? new Date().getFullYear();
         let month = options.month ?? new Date().getMonth() + 1;
+
+        if (options.date) {
+            year = options.date.getFullYear();
+            month = options.date.getMonth() + 1;
+        }
 
         try {
             const { data, error } = await fetchData<G>(

--- a/tests/leaderboard/monthly.test.ts
+++ b/tests/leaderboard/monthly.test.ts
@@ -32,4 +32,14 @@ describe("monthly leaderboard", () => {
         expect(data?.length).toBe(50);
         expect(error).toBe(null);
     });
+
+    test.concurrent("fetch single game with date", async () => {
+        const { data, error } = await getMonthlyLeaderboard(GAME.BlockDrop, {
+            date: new Date(2023, 0),
+        });
+
+        expect(data![0].id).toBe(GAME.BlockDrop);
+        expect(data?.length).toBe(100);
+        expect(error).toBe(null);
+    });
 });

--- a/tests/stats/monthly.test.ts
+++ b/tests/stats/monthly.test.ts
@@ -35,4 +35,26 @@ describe("monthly statistics", () => {
         ]);
         expect(error).toBe(null);
     });
+
+    test.concurrent("fetch single game with month and year", async () => {
+        const { data, error } = await getMonthlyStats(
+            "ucdfiddes",
+            GAME.TreasureWars,
+            { year: 2023, month: 6 }
+        );
+
+        expect(data?.id).toEqual(GAME.TreasureWars);
+        expect(error).toBe(null);
+    });
+
+    test.concurrent("fetch single game with date", async () => {
+        const { data, error } = await getMonthlyStats(
+            "ucdfiddes",
+            GAME.TreasureWars,
+            { date: new Date(2023, 5) }
+        );
+
+        expect(data?.id).toEqual(GAME.TreasureWars);
+        expect(error).toBe(null);
+    });
 });


### PR DESCRIPTION
Support an instance of the `Date` class in `getMonthlyLeaderboard()` and `getMonthlyStats()` options instead of the `year` and `month` properties