### PR TITLE
Add bedwars

### DIFF
--- a/docs/GAMES.md
+++ b/docs/GAMES.md
@@ -27,6 +27,28 @@ Fields which are only present in _All-Time statistics_, _Monthly statistics_, or
 | treasure_destroyed | `number` | How many treasures the player has destroyed                                                     |
 | prestige           | `number` | The prestige of the player                                                                      |
 
+## BedWars
+
+| Field          | Type     | Description                                                                                     |
+| -------------- | -------- | ----------------------------------------------------------------------------------------------- |
+| UUID           | `string` | _Only when getting all-time stats or leaderboards_ - The UUID of the player                     |
+| index          | `number` | _Only when getting monthly stats or leaderboards_ - The index                                   |
+| human_index    | `number` | _Only when getting monthly stats or leaderboards_ - The human index                             |
+| username       | `string` | _Only when getting monthly stats or leaderboards_ - The player's correctly capitalised username |
+| id             | `string` | The ID of the game (`bed` in this case)                                                         |
+| xp             | `number` | Total XP of the player                                                                          |
+| level          | `number` | Current level (calculated by the wrapper)                                                       |
+| played         | `number` | How many times the player has played this game                                                  |
+| first_played   | `number` | _Only when getting all-time stats_ - The unix timestamp the player first played this game       |
+| victories      | `number` | The number of times the player has won this game                                                |
+| losses         | `number` | The number of times the player has lost this game                                               |
+| win_percentage | `number` | The percentage of wins to total amount of games played                                          |
+| kdr            | `number` | Ratio of kills to deaths                                                                        |
+| deaths         | `number` | How many times the player has died in this game                                                 |
+| kills          | `number` | How many other players the player has killed in this game                                       |
+| final_kills    | `number` | How many other players the player has final killed in this game                                 |
+| beds_destroyed | `number` | How many beds the player has destroyed                                                          |
+
 ## Deathrun
 
 | Field          | Type     | Description                                                                                     |

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "license": "MIT",
     "author": "Cubeedge Studios",
     "dependencies": {
-        "hive-bedrock-data": "1.1.8"
+        "hive-bedrock-data": "1.1.9"
     },
     "scripts": {
         "prepack": "yarn build",

--- a/src/methods/getMonthlyLeaderboard.ts
+++ b/src/methods/getMonthlyLeaderboard.ts
@@ -1,8 +1,7 @@
-import { Game, Routes, Timeframe } from "hive-bedrock-data";
+import { Game, Timeframe } from "hive-bedrock-data";
 import { APIResponse, Options } from "../types/types";
 import fetchEndpoint from "../helpers/fetchEndpoint";
 import isGame from "../helpers/isGame";
-import processors from "../processors";
 import { LeaderboardResponse } from "../types/output";
 import getProcessors from "../processors";
 
@@ -49,7 +48,10 @@ export default async function getMonthlyLeaderboard<G extends Game>(
 
     return {
         ...response,
-        data: response_data,
+        data: response_data as unknown as LeaderboardResponse<
+            G,
+            Timeframe.Monthly
+        >,
         error: null,
     };
 }

--- a/src/methods/getMonthlyStatistics.ts
+++ b/src/methods/getMonthlyStatistics.ts
@@ -1,13 +1,8 @@
-import { Game, PlayerMetadata, Statistics, Timeframe } from "hive-bedrock-data";
+import { Game, Statistics, Timeframe } from "hive-bedrock-data";
 import { APIResponse, Options } from "../types/types";
-import {
-    AllGameStatistics,
-    AllStatistics,
-    StatisticsResponse,
-} from "../types/output";
+import { AllGameStatistics, StatisticsResponse } from "../types/output";
 import isGame from "../helpers/isGame";
 import fetchEndpoint from "../helpers/fetchEndpoint";
-import processors from "../processors";
 import getProcessors from "../processors";
 
 interface MonthlyOptions extends Options {

--- a/src/methods/getPlayerInfomation.ts
+++ b/src/methods/getPlayerInfomation.ts
@@ -1,4 +1,4 @@
-import { MapMetadata, PlayerMetadata } from "hive-bedrock-data";
+import { PlayerMetadata } from "hive-bedrock-data";
 import { APIResponse, Options } from "../types/types";
 import fetchEndpoint from "../helpers/fetchEndpoint";
 import { getPlayerProcessors } from "../processors";

--- a/src/types/output.ts
+++ b/src/types/output.ts
@@ -44,6 +44,7 @@ export interface AllStatistics<T extends Timeframe> {
     [Game.SurvivalGames]: BaseStatistics<Game.SurvivalGames, T> & PvPAdditions;
     [Game.TheBridge]: BaseStatistics<Game.TheBridge, T> & PvPAdditions;
     [Game.TreasureWars]: BaseStatistics<Game.TreasureWars, T> & PvPAdditions;
+    [Game.BedWars]: BaseStatistics<Game.BedWars, T> & PvPAdditions;
 }
 
 interface CommonLeaderboard {
@@ -76,6 +77,7 @@ export interface AllLeaderboards<T extends Timeframe> {
     [Game.SurvivalGames]: BaseLeaderboard<Game.SurvivalGames, T>[];
     [Game.TheBridge]: BaseLeaderboard<Game.TheBridge, T>[];
     [Game.TreasureWars]: BaseLeaderboard<Game.TreasureWars, T>[];
+    [Game.BedWars]: BaseLeaderboard<Game.BedWars, T>[];
 }
 
 export type AllGameStatistics<T extends Timeframe> = {


### PR DESCRIPTION
Add the new game, BedWars to the hive-bedrock-api wrapper. This uses data from hive-bedrock-data@1.1.9